### PR TITLE
refac: add Digest traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "autocfg"
@@ -80,9 +80,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -134,9 +134,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -203,7 +203,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "plonky2"
 version = "0.2.2"
-source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#3c4cc3749683a82477dcfcea19d423fe844c3ed6"
+source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#22c42f64367e8f087e565bdb664525910a62fc76"
 dependencies = [
  "ahash",
  "anyhow",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.2.2"
-source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#3c4cc3749683a82477dcfcea19d423fe844c3ed6"
+source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#22c42f64367e8f087e565bdb664525910a62fc76"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -613,7 +613,7 @@ checksum = "92ff44a90aaca13e10e7ddf8fab815ba1b404c3f7c3ca82aaf11c46beabaa923"
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.2.0"
-source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#3c4cc3749683a82477dcfcea19d423fe844c3ed6"
+source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#22c42f64367e8f087e565bdb664525910a62fc76"
 dependencies = [
  "rayon",
 ]
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.2.0"
-source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#3c4cc3749683a82477dcfcea19d423fe844c3ed6"
+source = "git+https://github.com/Lagrange-Labs/plonky2?branch=upstream#22c42f64367e8f087e565bdb664525910a62fc76"
 
 [[package]]
 name = "powerfmt"
@@ -778,29 +778,29 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -833,7 +833,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1004,7 +1004,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -1026,7 +1026,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1165,5 +1165,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -96,7 +96,7 @@ where
             let mut h = state[7];
 
             for i in 0..16 {
-                let index = blk as usize * 512 + i * 32;
+                let index = blk * 512 + i * 32;
                 let u32_target = builder.le_sum(self.message[index..index + 32].iter().rev());
 
                 x.push(U32Target(u32_target));
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_sha256() -> Result<()> {
-        let mut msg = vec![0; 128 as usize];
+        let mut msg = vec![0; 128_usize];
         for i in 0..127 {
             msg[i] = i as u8;
         }
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_sha256_failure() {
-        let mut msg = vec![0; 128 as usize];
+        let mut msg = vec![0; 128_usize];
         for i in 0..127 {
             msg[i] = i as u8;
         }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -4,69 +4,11 @@ use plonky2::iop::target::BoolTarget;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2_crypto::u32::gadgets::arithmetic_u32::{CircuitBuilderU32, U32Target};
 
-#[rustfmt::skip]
-pub const H256: [u32; 8] = [
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
-];
-
-/// Constants necessary for SHA-256 family of digests.
-#[rustfmt::skip]
-pub const K256: [u32; 64] = [
-    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
-    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
-    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
-    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
-    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
-    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
-    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
-    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
-    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
-    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
-    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
-    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
-    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
-    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
-    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
-    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
-];
+use crate::utils::{bits_to_u32_target, u32_to_bits_target, H256, K256};
 
 pub struct Sha256Targets {
     pub message: Vec<BoolTarget>,
     pub digest: Vec<BoolTarget>,
-}
-
-pub fn array_to_bits(bytes: &[u8]) -> Vec<bool> {
-    let len = bytes.len();
-    let mut ret = Vec::new();
-    for i in 0..len {
-        for j in 0..8 {
-            let b = (bytes[i] >> (7 - j)) & 1;
-            ret.push(b == 1);
-        }
-    }
-    ret
-}
-
-pub fn u32_to_bits_target<F: RichField + Extendable<D>, const D: usize, const B: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    a: &U32Target,
-) -> Vec<BoolTarget> {
-    let mut res = Vec::new();
-    let bit_targets = builder.split_le_base::<B>(a.0, 32);
-    for i in (0..32).rev() {
-        res.push(BoolTarget::new_unsafe(bit_targets[i]));
-    }
-    res
-}
-
-pub fn bits_to_u32_target<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    bits_target: Vec<BoolTarget>,
-) -> U32Target {
-    let bit_len = bits_target.len();
-    assert_eq!(bit_len, 32);
-    U32Target(builder.le_sum(bits_target[0..32].iter().rev()))
 }
 
 // define ROTATE(x, y)  (((x)>>(y)) | ((x)<<(32-(y))))
@@ -406,7 +348,8 @@ mod tests {
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use rand::Rng;
 
-    use crate::circuit::{array_to_bits, make_circuits};
+    use crate::circuit::make_circuits;
+    use crate::utils::array_to_bits;
 
     const EXPECTED_RES: [u8; 256] = [
         0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod circuit;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
     builder.try_init()?;
 
     const MSG_SIZE: usize = 2828;
-    let mut msg = vec![0; MSG_SIZE as usize];
+    let mut msg = vec![0; MSG_SIZE];
     for i in 0..MSG_SIZE - 1 {
         msg[i] = i as u8;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 use plonky2::util::timing::TimingTree;
-use plonky2_sha256::circuit::{array_to_bits, make_circuits};
+use plonky2_sha256::circuit::make_circuits;
+use plonky2_sha256::utils::array_to_bits;
 use sha2::{Digest, Sha256};
 
 pub fn prove_sha256(msg: &[u8]) -> Result<()> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,65 @@
+use plonky2::{
+    field::extension::Extendable, hash::hash_types::RichField, iop::target::BoolTarget,
+    plonk::circuit_builder::CircuitBuilder,
+};
+use plonky2_crypto::u32::arithmetic_u32::U32Target;
+
+#[rustfmt::skip]
+pub const H256: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+];
+
+/// Constants necessary for SHA-256 family of digests.
+#[rustfmt::skip]
+pub const K256: [u32; 64] = [
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+];
+
+pub fn array_to_bits(bytes: &[u8]) -> Vec<bool> {
+    let len = bytes.len();
+    let mut ret = Vec::new();
+    for i in 0..len {
+        for j in 0..8 {
+            let b = (bytes[i] >> (7 - j)) & 1;
+            ret.push(b == 1);
+        }
+    }
+    ret
+}
+
+pub fn u32_to_bits_target<F: RichField + Extendable<D>, const D: usize, const B: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    a: &U32Target,
+) -> Vec<BoolTarget> {
+    let mut res = Vec::new();
+    let bit_targets = builder.split_le_base::<B>(a.0, 32);
+    for i in (0..32).rev() {
+        res.push(BoolTarget::new_unsafe(bit_targets[i]));
+    }
+    res
+}
+
+pub fn bits_to_u32_target<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    bits_target: Vec<BoolTarget>,
+) -> U32Target {
+    let bit_len = bits_target.len();
+    assert_eq!(bit_len, 32);
+    U32Target(builder.le_sum(bits_target[0..32].iter().rev()))
+}


### PR DESCRIPTION
This PR introduces `Digest` traits for `Sha256Targets` to digest data successively in a chained manner. The main Sha256 gadget logic is refactored into the following inline functions:
- `new()`: construct hasher with empty data
- `update()`: update input message
- `chain_update()`: update in a chained manner
- `finalize()`: return the digested data